### PR TITLE
[AWS S3] add delimiter to query for objects

### DIFF
--- a/pkg/s3/s3_service.go
+++ b/pkg/s3/s3_service.go
@@ -86,11 +86,12 @@ func (ps3 *S3Client) ListBuckets(ctx context.Context) (*BucketLists, error) {
 	return &res, nil
 }
 
-func (ps3 *S3Client) ListFiles(ctx context.Context, bucket, prefix *string) (*FileLists, error) {
+func (ps3 *S3Client) ListFiles(ctx context.Context, bucket, prefix, delimiter *string) (*FileLists, error) {
 
 	input := &s3.ListObjectsV2Input{
-		Bucket: bucket,
-		Prefix: prefix,
+		Bucket:    bucket,
+		Prefix:    prefix,
+		Delimiter: delimiter,
 	}
 
 	result, err := ps3.Client.ListObjectsV2(ctx, input)


### PR DESCRIPTION
Seems like the function is not used anywhere in Phil. Seems to be safe to make changes.
https://github.com/search?q=org%3Aphil-inc+ListFiles&type=code

Tested 3 scenarios (see video)

1. delimiter is not passed as an input
2. delimiter is passed with empty string (does the same behavior as 1)
3. delimiter is passed with "/"

All scenarios passed expected behavior.
https://user-images.githubusercontent.com/98766127/192382761-e63961d2-a215-4ad9-a1c8-4ff5f2deff1e.mp4


