### PR TITLE
Zoho ndc used as sku

### DIFF
--- a/pkg/ndc/ndc.go
+++ b/pkg/ndc/ndc.go
@@ -159,22 +159,23 @@ func AddDashesTo10Digit(s string) string {
 	return fmt.Sprintf("%s-0%s-%s", s[:5], s[5:8], s[8:])
 }
 
-// NDCFromZohoSKU returns NDC from SKU with format X10-digit-NDCY
+// FromZohoSKU returns NDC from SKU with format X10-digit-NDC
+// If SKU length is 11, it could be the actual SKU.
+// Else, if SKU format is not based on the agreed spec
 func FromZohoSKU(formattedSKu string) string {
 	sku := strings.ReplaceAll(formattedSKu, "-", "")
 	skuLength := len(sku)
 
-	// if SKU format is not based on the agreed spec
-	if skuLength != 12 {
-		return formattedSKu
+	switch skuLength {
+	case 11: //actual NDC without dashes
+		return fmt.Sprintf("%s-%s-%s", sku[:5], sku[5:9], sku[9:])
+	case 12:
+		sku = string(sku[1 : skuLength-1]) // remove first and last charatcer from sku
+		return AddDashesTo10Digit(sku)
 	}
 
-	// remove first and last charatcer from sku
-	sku = string(sku[1 : skuLength-1])
-
-	return AddDashesTo10Digit(sku)
+	return formattedSKu
 }
-
 func isLeadingZero(part string) bool {
 	return part[0] == '0'
 }

--- a/pkg/ndc/ndc_test.go
+++ b/pkg/ndc/ndc_test.go
@@ -1,0 +1,21 @@
+package ndc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Test for converting Zoho SKU to NDC
+func TestFromZohoSKU(t *testing.T) {
+	// SKU length is 11
+	assert.Equal(t, "59630-0580-90", FromZohoSKU("59630058090"))
+	assert.Equal(t, "59630-0580-90", FromZohoSKU("59630-0580-90"))
+
+	// SKU length is 12
+	assert.Equal(t, "00378-8082-20", FromZohoSKU("303788082207"))
+	assert.Equal(t, "51862-0462-60", FromZohoSKU("351862462605"))
+
+	// default
+	assert.Equal(t, "1234", FromZohoSKU("1234"))
+}


### PR DESCRIPTION
FromZohoSKU already returns a valid NDC from a valid SKU. 

However, is some cases, NDC is used as the SKU if WWS does not have the product yet. This causes us not to report on this POs/SOs that don't have a valid SKU. 

See in Zoho:
![image](https://user-images.githubusercontent.com/98766127/226413657-fcdd5f58-8e1d-4856-bc0f-e14741745fd2.png)


Impact is only on EDI.
https://github.com/search?q=org%3Aphil-inc+FromZohoSKU&type=code