### PR TITLE
Add util to get state abbreaviation from full name

### DIFF
--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -573,6 +573,21 @@ func GetFullStateNameFromAbbreviation(state string) string {
 	return StateAbbreviation[state]
 }
 
+// Get state abbreviation from full name
+func GetStateAbbreviationFromName(state string) string {
+	if len(state) <= 2 {
+		return state
+	}
+
+	for k, v := range StateAbbreviation {
+		if strings.EqualFold(v, state) {
+			return k
+		}
+	}
+
+	return state
+}
+
 func correctFloatValue(val interface{}) float64 {
 	var fval float64
 


### PR DESCRIPTION
## Description of the change
- Added util function to get state abbreviation from state full name.
Eg: For `California` we would get `CA` 
