### PR TITLE
Add constant for LongFormat date format

### DIFF
--- a/pkg/util/constants.go
+++ b/pkg/util/constants.go
@@ -18,6 +18,7 @@ const EstTimeZone = "America/New_York"
 const CstTimeZone = "America/Chicago"
 const MstTimeZone = "America/Phoenix"
 const YYYYMMDDFormater = "20060102"
+const LongFormat = "2006-01-02 15:04:05.999999999 -0700 MST"
 
 const (
 	UtmSrc            = "utm_src"


### PR DESCRIPTION
We do not have a constant for LongFormat date format, adding it since it could be used across multiple implementations for date conversions and so.