### PR TITLE
Remove function ReadFileFromLegacySFTP

### DIFF
--- a/pkg/network/sftp.go
+++ b/pkg/network/sftp.go
@@ -193,20 +193,3 @@ func ReadFileFromSFTPUsingPrivateKey(user, privateKey, address, srcFile, dstFile
 
 	return ReadFileFromSFTPUsingConfig(config, address, srcFile, dstFile)
 }
-
-func ReadFileFromLegacySFTP(usr, password, address, srcFile, dstFile string) (int64, error) {
-	config := &ssh.ClientConfig{
-		User: usr,
-		HostKeyCallback: func(hostname string, remote net.Addr, key ssh.PublicKey) error {
-			return nil
-		},
-		Auth: []ssh.AuthMethod{
-			ssh.Password(password),
-		},
-	}
-
-	config.Ciphers = append(config.Ciphers, "aes256-cbc")
-	config.HostKeyAlgorithms = append(config.HostKeyAlgorithms, "ssh-dss")
-
-	return ReadFileFromSFTPUsingConfig(config, address, srcFile, dstFile)
-}


### PR DESCRIPTION
### Background
We were using function ReadFileFromLegacySFTP to download master insurance file from change healthcare SFTP. But since, they have updated the cipher to use cbc based cipher. This isn't supported by Go, we have migrated it to workflow.

Therefore, this function isn't used elsewhere.