### PR TITLE
FIX: Enhance isInternalEmail Function to Validate Domain Endings

### DIFF
--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -671,7 +671,7 @@ func GetDiscreetRxName(rxName string) string {
 }
 
 func IsInternalEmail(email string) bool {
-	return strings.Contains(email, "phil.us") || strings.Contains(email, "usephil.com")
+	return strings.HasSuffix(email, "@phil.us") || strings.HasSuffix(email, "@usephil.com")
 }
 
 // StringData fetch string data from events data map


### PR DESCRIPTION
## Description of the change

> Update IsInternalEmail check for email validation to performed based on the string suffix/ending.

if the user contains an email with the name like `sailesh.phil.us@lftechnology.com` it will pass the current validation.

## Changes

* use hasSuffix instead of contains

## Test
https://go.dev/play/p/oof_AxSCufd
> test cases with old `IsInternalEmail` check

https://go.dev/play/p/C4paCiq-m81
> test cases with updated `IsInternalEmail` check