### PR TITLE
Add: HTTP GET response body, which was missing from HTTPGet Func

### DIFF
--- a/pkg/network/http.go
+++ b/pkg/network/http.go
@@ -232,6 +232,11 @@ func HTTPDataUpload(url, usrName, password string, body bytes.Buffer, headers ma
 	return nil, fmt.Errorf("http response NOT_OK. Status: %s, Code:%d", resp.Status, resp.StatusCode)
 }
 
+// HTTPJsonGet - sends JSON string data as get request
+func HTTPJsonGet(url string, headers map[string]string) ([]byte, error) {
+	return doHTTP(url, "GET", "", headers)
+}
+
 // HTTPJsonPost - sends JSON string data as post request
 func HTTPJsonPost(url, jsonBody string, headers map[string]string) ([]byte, error) {
 	return doHTTP(url, "POST", jsonBody, headers)


### PR DESCRIPTION
## Description of the change

> HTTP Get didn't return the Response body when there was an ERROR message. 

## Type of change

[] Bug Fix
[x] New Feature

## Changes

- [x] Add: HTTPJsonGET func like in HTTPJonPOST such that we have access to the response body for error, which holds important details (additional) for debugging. 
