### PR TITLE
Add support for multiple db connections

### DIFF
--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -83,6 +83,26 @@ func Setup(connConfig *Config) error {
 	return nil
 }
 
+// SetupPool - creates connection to Postgres database and returns the pool
+func SetupPool(connConfig *Config) (*pgx.ConnPool, error) {
+	pool, err := connectPostgres(connConfig)
+
+	// Fallback to ssl disable
+	if err != nil && connConfig.SSLMode != "disable" {
+		connConfig.SSLMode = "disable"
+		connConfig.SSLRootCert = ""
+		logger.Infof("Error connecting to postgres using sslmode=%s. Falling back to sslmode=disable", connConfig.SSLMode)
+		pool, err = connectPostgres(connConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	logger.Infof("Connected to postgres using sslmode=%s", connConfig.SSLMode)
+	return pool, nil
+}
+
+// DB - returns the global connection pool
 func DB() *pgx.ConnPool {
 	if pool == nil {
 		err := Setup(config)
@@ -111,7 +131,17 @@ func (r Rows) NextRow() (bool, error) {
 	return false, nil
 }
 
+// ExecQuery - executes query using the global pool
 func ExecQuery(queryWithNamedParams string, params map[string]interface{}) (*Rows, error) {
+	return execQueryWithPool(DB(), queryWithNamedParams, params)
+}
+
+// ExecQueryWithPool - executes query using a specific pool
+func ExecQueryWithPool(pool *pgx.ConnPool, queryWithNamedParams string, params map[string]interface{}) (*Rows, error) {
+	return execQueryWithPool(pool, queryWithNamedParams, params)
+}
+
+func execQueryWithPool(pool *pgx.ConnPool, queryWithNamedParams string, params map[string]interface{}) (*Rows, error) {
 	paramArr := []interface{}{}
 	count := 1
 
@@ -128,5 +158,4 @@ func ExecQuery(queryWithNamedParams string, params map[string]interface{}) (*Row
 	}
 
 	return &Rows{Rows: *pr}, nil
-
 }

--- a/pkg/postgres/postgres.go
+++ b/pkg/postgres/postgres.go
@@ -151,8 +151,7 @@ func execQueryWithPool(pool *pgx.ConnPool, queryWithNamedParams string, params m
 		count++
 	}
 
-	db := DB()
-	pr, err := db.Query(queryWithNamedParams, paramArr...)
+	pr, err := pool.Query(queryWithNamedParams, paramArr...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description of the change

> Add support to connect multiple db simultaneously
> The change is backward compatible, as it retain the global variables and related functions.

## Type of change
- [x] New Feature

## Changes
* Add support for connection of multiple postgres db simultaneously.

## Example Usage

```go
func main() {
    // Using the global connection pool
    config := &postgres.Config{
        URL:         "postgres://user:password@localhost:5432",
        DBName:      "database1",
        SSLMode:     "disable",
    }

    err := postgres.Setup(config)
    if err != nil {
        logger.Panicf("Error setting up global connection pool: %s", err)
    }

    query := "SELECT * FROM table WHERE id = :id"
    params := map[string]interface{}{
        "id": 1,
    }

    rows, err := postgres.ExecQuery(query, params)
    if err != nil {
        logger.Errorf("Error executing query on global pool: %s", err)
    }

    // Using a specific connection pool
    config2 := &postgres.Config{
        URL:         "postgres://user:password@localhost:5432",
        DBName:      "database2",
        SSLMode:     "disable",
    }

    pool2, err := postgres.SetupPool(config2)
    if err != nil {
        logger.Panicf("Error setting up connection pool for database2: %s", err)
    }

    rows2, err := postgres.ExecQueryWithPool(pool2, query, params)
    if err != nil {
        logger.Errorf("Error executing query on database2 pool: %s", err)
    }

    ........
}


```
