### PR TITLE
Circuit breaker for network calls

### DIFF
--- a/pkg/circuitbreaker/circuit_breaker.go
+++ b/pkg/circuitbreaker/circuit_breaker.go
@@ -1,0 +1,126 @@
+package circuitbreaker
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/phil-inc/pcommon/pkg/redis"
+)
+
+var redisClient *redis.RedisClient
+var ctx = context.Background() //TODO
+
+func SetupRedis(url string) {
+	redisClient := new(redis.RedisClient)
+	redisClient.SetupRedis(url)
+}
+
+type State string
+
+const (
+	Closed   State = "CLOSED"
+	Open     State = "OPEN"
+	HalfOpen State = "HALF_OPEN"
+)
+
+type CircuitBreaker struct {
+	state                    State
+	failureThreshold         int
+	failureCount             int
+	successCount             int
+	mu                       sync.Mutex
+	halfOpenSuccessThreshold int
+	openTimeout              time.Duration
+	lastFailureTime          time.Time
+	url                      string
+}
+
+func NewCircuitBreaker(url string, failureThreshold int, halfOpenSuccessThreshold int, openTimeout time.Duration) *CircuitBreaker {
+	cb := &CircuitBreaker{
+		url:                      url,
+		failureThreshold:         failureThreshold,
+		halfOpenSuccessThreshold: halfOpenSuccessThreshold,
+		openTimeout:              openTimeout,
+	}
+
+	// Load initial state from Redis
+	cb.loadState()
+
+	return cb
+}
+
+func (cb *CircuitBreaker) loadState() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	state, err := redisClient.HGetAll(ctx, cb.url).Result()
+	if err == nil && len(state) > 0 {
+		cb.state = State(state["state"])
+		cb.failureCount, _ = strconv.Atoi(state["failureCount"])
+		cb.successCount, _ = strconv.Atoi(state["successCount"])
+		cb.lastFailureTime, _ = time.Parse(time.RFC3339, state["lastFailureTime"])
+	}
+}
+
+func (cb *CircuitBreaker) saveState() {
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	state := map[string]interface{}{
+		"state":           cb.state,
+		"failureCount":    cb.failureCount,
+		"successCount":    cb.successCount,
+		"lastFailureTime": cb.lastFailureTime.Format(time.RFC3339),
+	}
+
+	redisClient.HMSet(ctx, cb.url, state)
+}
+
+func (cb *CircuitBreaker) Call(f func() ([]byte, error)) ([]byte, error) {
+	cb.mu.Lock()
+
+	switch cb.state {
+	case Open:
+		if time.Since(cb.lastFailureTime) > cb.openTimeout {
+			cb.state = HalfOpen
+		} else {
+			cb.mu.Unlock()
+			return nil, fmt.Errorf("circuit breaker is open")
+		}
+	case HalfOpen:
+		if cb.successCount >= cb.halfOpenSuccessThreshold {
+			cb.state = Closed
+			cb.failureCount = 0
+			cb.successCount = 0
+		}
+	}
+
+	// Release lock before function call
+	cb.mu.Unlock()
+
+	resp, err := f()
+
+	cb.mu.Lock()
+	defer cb.mu.Unlock()
+
+	if err != nil {
+		cb.failureCount++
+		if cb.failureCount >= cb.failureThreshold {
+			cb.state = Open
+			cb.lastFailureTime = time.Now()
+		}
+		cb.saveState() // Save state after failure
+		return nil, err
+	}
+
+	if cb.state == HalfOpen {
+		cb.successCount++
+	}
+
+	cb.saveState() // Save state after success
+
+	return resp, nil
+}

--- a/pkg/circuitbreaker/circuit_breaker.go
+++ b/pkg/circuitbreaker/circuit_breaker.go
@@ -15,7 +15,7 @@ var redisClient *redis.RedisClient
 var ctx = context.Background() //TODO
 
 func SetupRedis(url string) {
-	redisClient := new(redis.RedisClient)
+	redisClient = new(redis.RedisClient)
 	redisClient.SetupRedis(url)
 }
 
@@ -75,11 +75,9 @@ func (cb *CircuitBreaker) loadState() error {
 }
 
 func (cb *CircuitBreaker) saveState() error {
-	cb.mu.Lock()
-	defer cb.mu.Unlock()
 
 	state := map[string]interface{}{
-		"state":           cb.state,
+		"state":           string(cb.state),
 		"failureCount":    cb.failureCount,
 		"successCount":    cb.successCount,
 		"lastFailureTime": cb.lastFailureTime.Format(time.RFC3339),
@@ -131,8 +129,6 @@ func (cb *CircuitBreaker) Call(f func() ([]byte, error)) ([]byte, error) {
 }
 
 func (cb *CircuitBreaker) transitionToHalfOpen() {
-	cb.mu.Lock()
-	defer cb.mu.Unlock()
 	cb.state = HalfOpen
 	cb.failureCount = 0
 	cb.successCount = 0
@@ -140,8 +136,6 @@ func (cb *CircuitBreaker) transitionToHalfOpen() {
 }
 
 func (cb *CircuitBreaker) transitionToClosed() {
-	cb.mu.Lock()
-	defer cb.mu.Unlock()
 	cb.state = Closed
 	cb.failureCount = 0
 	cb.successCount = 0

--- a/pkg/circuitbreaker/config.go
+++ b/pkg/circuitbreaker/config.go
@@ -1,0 +1,42 @@
+package circuitbreaker
+
+import (
+	"sync"
+	"time"
+)
+
+type CircuitBreakerConfig struct {
+	FailureThreshold int
+	HalfOpenSuccess  int
+	OpenTimeout      time.Duration
+}
+
+var (
+	configurations = make(map[string]CircuitBreakerConfig)
+	configMu       sync.Mutex
+)
+
+// SetCircuitBreakerConfig sets the configuration for a given URL.
+func SetCircuitBreakerConfig(url string, config CircuitBreakerConfig) {
+	configMu.Lock()
+	defer configMu.Unlock()
+	configurations[url] = config
+}
+
+// GetCircuitBreakerConfig retrieves the configuration for a given URL.
+func GetCircuitBreakerConfig(url string) CircuitBreakerConfig {
+	configMu.Lock()
+	defer configMu.Unlock()
+
+	config, exists := configurations[url]
+	if !exists {
+		// Default settings if not configured
+		return CircuitBreakerConfig{
+			FailureThreshold: 20,
+			HalfOpenSuccess:  10,
+			OpenTimeout:      time.Minute * 5,
+		}
+	}
+
+	return config
+}

--- a/pkg/circuitbreaker/config.go
+++ b/pkg/circuitbreaker/config.go
@@ -27,7 +27,7 @@ func SetCircuitBreakerConfig(url string, config CircuitBreakerConfig) {
 func GetCircuitBreakerConfig(url string) CircuitBreakerConfig {
 	configMu.Lock()
 	defer configMu.Unlock()
-
+	//TODO: Normalize the url before fetching
 	config, exists := configurations[url]
 	if !exists {
 		// Default settings if not configured


### PR DESCRIPTION
## Description of the change

>Currently our inbound and outbound network calls have no mechanism to failover or pause the calls if some error is happening, which sometimes result in hundreds of retries which result in error.

Implement a circuit breaker pattern around network calls which take into account any errors that has happened recently and can temporarily pause the calls if needed according to configuration.

* Jira link, if available


## Type of change

[] Bug Fix
[x] New Fearure

## Changes

* What changes are included in this PR

## Impact

* Any infrastructure related impact
* Any security related impact
