### PR TITLE
Compare pointer values

### DIFF
--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -1173,3 +1173,39 @@ func NormalizeSpace(s string) string {
 	space := regexp.MustCompile(`\s+`)
 	return space.ReplaceAllString(s, " ")
 }
+
+// IsEqualPointerValues compares two pointers of any type, including *time.Time pointers.
+// If both pointers are nil, it returns true. If only one is nil, it returns false.
+// For *time.Time pointers, it uses the time.Time.Equal method for accurate comparison.
+// For other pointer types, it uses reflect.DeepEqual to compare the dereferenced values.
+//
+// Parameters:
+//   - p1: The first pointer to compare.
+//   - p2: The second pointer to compare.
+//
+// Returns:
+//   - A boolean value indicating whether the two pointers are equal.
+func IsEqualPointerValues(p1, p2 interface{}) bool {
+	// If either pointer is nil, return whether they are both nil
+	if p1 == nil || p2 == nil {
+		return p1 == p2
+	}
+
+	// Handle *time.Time comparison explicitly
+	if t1, ok1 := p1.(*time.Time); ok1 {
+		if t2, ok2 := p2.(*time.Time); ok2 {
+			return t1.Equal(*t2)
+		}
+	}
+
+	v1 := reflect.ValueOf(p1)
+	v2 := reflect.ValueOf(p2)
+
+	if v1.Kind() != reflect.Ptr || v2.Kind() != reflect.Ptr {
+		// Return false if either is not a pointer
+		return false
+	}
+
+	// Dereference the pointers and compare their values using reflect.DeepEqual
+	return reflect.DeepEqual(v1.Elem().Interface(), v2.Elem().Interface())
+}

--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -1174,7 +1174,7 @@ func NormalizeSpace(s string) string {
 	return space.ReplaceAllString(s, " ")
 }
 
-// IsEqualPointerValues compares two pointers of any type, including *time.Time pointers.
+// ArePointerValuesEqual compares two pointers of any type, including *time.Time pointers.
 // If both pointers are nil, it returns true. If only one is nil, it returns false.
 // For *time.Time pointers, it uses the time.Time.Equal method for accurate comparison.
 // For other pointer types, it uses reflect.DeepEqual to compare the dereferenced values.
@@ -1185,7 +1185,7 @@ func NormalizeSpace(s string) string {
 //
 // Returns:
 //   - A boolean value indicating whether the two pointers are equal.
-func IsEqualPointerValues(p1, p2 interface{}) bool {
+func ArePointerValuesEqual(p1, p2 interface{}) bool {
 	// If either pointer is nil, return whether they are both nil
 	if p1 == nil || p2 == nil {
 		return p1 == p2


### PR DESCRIPTION
## Description of the change

Added a function `ArePointerValuesEqual` to compare if the values of two pointers are Equal


## Type of change
- New Feature

## Changes

* Added a function `ArePointerValuesEqual` to compare if the values of two pointers are Equal
Example usage:
```go
package main

import (
	"fmt"
	"time"
)

func main() {
	a, b := 5, 5
	fmt.Println(ArePointerValuesEqual(&a, &b)) // true

	bool1, bool2 := true, false
	fmt.Println(ArePointerValuesEqual(&bool1, &bool2)) // false

	str1, str2 := "hello", "world"
	fmt.Println(ArePointerValuesEqual(&str1, &str2)) // false

	now := time.Now()
	fmt.Println(ArePointerValuesEqual(&now, &now)) // true

	fmt.Println(ArePointerValuesEqual(nil, nil))   // true
	fmt.Println(ArePointerValuesEqual(&a, nil))    // false
}
```
