### PR TITLE
Change NextDay calculation from adding hours to whole 1 day.

### DIFF
--- a/pkg/util/date.go
+++ b/pkg/util/date.go
@@ -297,7 +297,7 @@ func AddWorkingDays(d time.Time, totalDays int) time.Time {
 		}
 
 		totalDays--
-		d = d.Add(time.Hour * 24)
+		d = d.AddDate(0, 0, 1)
 	}
 
 	//check if the last day is itself a holiday
@@ -341,7 +341,7 @@ func GetPreviousWorkingDay(d time.Time) time.Time {
 // GetNextWorkingDay returns the next working date from the given date
 func GetNextWorkingDay(d time.Time) time.Time {
 	for {
-		d = d.Add(time.Hour * 24)
+		d = d.AddDate(0, 0, 1)
 		if IsWorkingDay(d) {
 			return d
 		}

--- a/pkg/util/date.go
+++ b/pkg/util/date.go
@@ -317,7 +317,7 @@ func SubtractWorkingDays(d time.Time, totalDays int) time.Time {
 		}
 
 		totalDays--
-		d = d.Add(-1 * time.Hour * 24)
+		d = d.AddDate(0, 0, -1)
 	}
 
 	//check if the last day is itself a holiday
@@ -331,7 +331,7 @@ func SubtractWorkingDays(d time.Time, totalDays int) time.Time {
 // GetPreviousWorkingDay returns the previous working date from the given date
 func GetPreviousWorkingDay(d time.Time) time.Time {
 	for {
-		d = d.Add(-1 * time.Hour * 24)
+		d = d.AddDate(0, 0, -1)
 		if IsWorkingDay(d) {
 			return d
 		}


### PR DESCRIPTION
## Description of the change

> Change NextDay calculation from adding hours to whole 1 day.

* [Jira link](https://phildotus.atlassian.net/browse/DWMC-5253?focusedCommentId=91007)

## Type of change

[x] Bug Fix
[] New Fearure

## Changes

* We faced an issue where the addition of 24 hours led to the addition of 23 hours only due to the transition of DST.
* To fix this add a whole 1 day instead of an hour.
