### PR TITLE
Implement builder pattern for bedrock_agent

### DIFF
--- a/pkg/aws/bedrock_agent/bedrock_agent.go
+++ b/pkg/aws/bedrock_agent/bedrock_agent.go
@@ -71,14 +71,11 @@ func (b *Builder) Build() (*Service, error) {
 		b.awsConfig = &awsConfig
 	}
 
-	b.agentClient = bedrockagent.NewFromConfig(*b.awsConfig)
-	b.agentRuntimeClient = bedrockagentruntime.NewFromConfig(*b.awsConfig)
-
 	return &Service{
 		config:             b.config,
 		awsConfig:          b.awsConfig,
-		agentClient:        b.agentClient,
-		agentRuntimeClient: b.agentRuntimeClient,
+		agentClient:        bedrockagent.NewFromConfig(*b.awsConfig),
+		agentRuntimeClient: bedrockagentruntime.NewFromConfig(*b.awsConfig),
 	}, nil
 }
 

--- a/pkg/aws/bedrock_agent/bedrock_agent_test.go
+++ b/pkg/aws/bedrock_agent/bedrock_agent_test.go
@@ -3,8 +3,6 @@ package bedrock_agent
 import (
 	"context"
 	"testing"
-
-	"github.com/aws/aws-sdk-go-v2/config"
 )
 
 func TestLiveAgent(t *testing.T) {
@@ -15,14 +13,10 @@ func TestLiveAgent(t *testing.T) {
 		Region:       "us-east-1",
 	}
 
-	awsCfg, err := config.LoadDefaultConfig(context.Background(),
-		config.WithRegion(cfg.Region),
-	)
+	service, err := New().Config(&cfg).Build()
 	if err != nil {
-		t.Fatalf("Failed to load AWS config: %v", err)
+		t.Fatalf("Failed to create service: %v", err)
 	}
-
-	service := New().Config(cfg).AWSConfig(awsCfg).Build()
 
 	cardHistory := `{"hello"}`
 

--- a/pkg/aws/bedrock_agent/bedrock_agent_test.go
+++ b/pkg/aws/bedrock_agent/bedrock_agent_test.go
@@ -3,6 +3,8 @@ package bedrock_agent
 import (
 	"context"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/config"
 )
 
 func TestLiveAgent(t *testing.T) {
@@ -13,10 +15,14 @@ func TestLiveAgent(t *testing.T) {
 		Region:       "us-east-1",
 	}
 
-	service, err := NewService(cfg)
+	awsCfg, err := config.LoadDefaultConfig(context.Background(),
+		config.WithRegion(cfg.Region),
+	)
 	if err != nil {
-		t.Fatalf("Failed to create service: %v", err)
+		t.Fatalf("Failed to load AWS config: %v", err)
 	}
+
+	service := New().Config(cfg).AWSConfig(awsCfg).Build()
 
 	cardHistory := `{"hello"}`
 


### PR DESCRIPTION
## Description of the change

Implements the builder pattern for the bedrock_agent package so that the AWS config can be passed in

* https://phildotus.atlassian.net/browse/ISCE-584


## Type of change

[] Bug Fix
[x] New Feature

## Changes

* Implemented the builder pattern for the bedrock_agent package
* Updated the test to pass in the default AWS config and pass

## Impact

* Any infrastructure related impact
* Any security related impact
