### PR TITLE
Order number format validation

### DIFF
--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -1219,3 +1219,9 @@ func ArePointerValuesEqual(p1, p2 interface{}) bool {
 	// Dereference the pointers and compare their values using reflect.DeepEqual
 	return reflect.DeepEqual(v1.Elem().Interface(), v2.Elem().Interface())
 }
+
+// checks if the string is a valid order number (Valid Format: xxxx-xx/xxxx-xxx/xxxx)
+func IsOrderNumber(text string) bool {
+	matched, _ := regexp.MatchString(`^((\d{4})-(\d{2}|\d{4})-(\d{3,4}))$`, text)
+	return matched
+}


### PR DESCRIPTION
## Description of the change

> Checks if the given string follows a valid order number format. This is required for migrating RxHistory from OPS Dash to Thanos. Previously, order number format validation was implemented in CAPI (https://github.com/phil-inc/capi/blob/41fb1c81d188cf29ec97507f0a9409b96e99cb19/plib/service/base_service.go#L201) for every event request based on the order number

## Type of change
- A new util function is added to the pkg -> util

[] Bug Fix
[x] New Fearure

## Changes
- Added a util function that validates the order number format using regex. Returns true if it matches the provided regex; otherwise, returns false.

## Screenshot
![orderTest](https://github.com/user-attachments/assets/70571dfb-5d1f-47e7-ba4d-5bc3d8784d9d)
