### PR TITLE
[Review] convert time to PST before getting date

### DIFF
--- a/pkg/util/date.go
+++ b/pkg/util/date.go
@@ -156,11 +156,13 @@ func DayEndTime() time.Time {
 
 // DateStartTimePST return the start date time for given date as PST
 func DateStartTimePST(t *time.Time) time.Time {
+	t = ToPST(t)
 	return time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, LocationPST)
 }
 
 // DateEndTimePST return the end date time for given date as PST
 func DateEndTimePST(t *time.Time) time.Time {
+	t = ToPST(t)
 	return time.Date(t.Year(), t.Month(), t.Day(), 23, 59, 59, 0, LocationPST)
 }
 


### PR DESCRIPTION
## Description of the change

> convert time to PST before getting date

* https://phildotus.atlassian.net/browse/DWMC-6299


## Type of change

[x] Bug Fix
[] New Fearure

## Changes

* When getting DateStartTimePST, convert time to PST first. 

## Reference
* When the time is between 16:00~24:00 PST, the UTC date is one day after the PST date. 
![image](https://github.com/user-attachments/assets/01ca89a3-b7f1-4268-817f-57351179ff5a)
* All the time objects saved in db are in UTC format. If not converted to PST first, we cannot get the correct date if time is in this range. Test result: https://go.dev/play/p/32yxfi3CG67
![image](https://github.com/user-attachments/assets/e583fa23-c9ad-4693-8fd1-c4857b13bd71)


## Impact

* PA termination date
* PA sleep timer
* Rx search query
* HCP user search query
* GenerateBillingData job
