### PR TITLE
Fix format string parsing error

### DIFF
--- a/pkg/network/http.go
+++ b/pkg/network/http.go
@@ -283,7 +283,7 @@ func doHTTP(url, method, body string, headers map[string]string) ([]byte, error)
 		errResp := fmt.Sprintf("Http response NOT_OK. Status: %s, Code:%d", res.Status, res.StatusCode)
 		if res.Body != nil {
 			resp, _ := ioutil.ReadAll(res.Body)
-			errResp = errResp + fmt.Sprintf(", Body: %s", resp)
+			errResp = errResp + ", Body: " + string(resp)
 		}
 
 		return nil, fmt.Errorf(errResp)


### PR DESCRIPTION
## Description of the change

Fix JSON unmarshalling error caused by unescaped % in response

Some responses contain strings with % characters that are valid and should not be escaped—for example: `drugStrength": "0.09%"`
When such responses are included in formatted messages using fmt.Sprintf without properly escaping %, it triggers a formatting error and produces output like: `"drugStrength": "0.09%!"(MISSING)`
This corrupts the JSON string and causes json.Unmarshal to fail.

This PR fixes the issue by avoiding the use of fmt.Sprintf on raw response bodies or by properly handling % characters, ensuring that the JSON remains valid and unmarshalling succeeds.





* https://phildotus.atlassian.net/browse/BRUN-3860


## Type of change

[x] Bug Fix
[ ] New Fearure
