### PR TITLE
Add DownloadToFile for Streaming S3 Objects to Disk

### DIFF
--- a/pkg/s3/s3_service.go
+++ b/pkg/s3/s3_service.go
@@ -198,7 +198,7 @@ func (ps3 *S3Client) UploadFileFromPath(ctx context.Context, bucket, fileName, f
 	return upload, nil
 }
 
-// DownloadFileIntoFile downloads an S3 object to the provided *os.File without loading the entire file into memory.
+// DownloadToFile downloads an S3 object to the provided *os.File without loading the entire file into memory.
 // Suitable for large files, as it streams the content directly to disk.
 // The caller is responsible for ensuring the file is open, writable, and closed after use.
 func (ps3 *S3Client) DownloadToFile(ctx context.Context, w *os.File, bucket, key string) error {


### PR DESCRIPTION
## Description of the change

>The S3 client currently lacks a method to download objects directly to disk, which is critical for handling large files efficiently. The new `DownloadToFile` method streams an S3 object to a provided `*os.File` without buffering in memory, optimizing performance and resource usage for large files.



## Type of change

[] Bug Fix
[x] New Fearure

## Changes


## Impact


