### PR TITLE
HCPDEV-222: Add helper to get PhilRx color logo

### DIFF
--- a/pkg/util/commons.go
+++ b/pkg/util/commons.go
@@ -1080,6 +1080,10 @@ func GetPhilRxLogoURL() string {
 	return fmt.Sprintf("%s/img/insert-card/PHILRX_Logo_Black.png", Config("dashboard.server.url"))
 }
 
+func GetPhilRxColorLogoURL() string {
+	return fmt.Sprintf("%s/img/insert-card/PHILRX_Logo_Color.png", Config("dashboard.server.url"))
+}
+
 func IsGreaterThan(number, value float64) bool {
 	return number > value
 }


### PR DESCRIPTION
## Description of the change

> We added the PhilRx color logo to AAPI, but need a helper to retrieve it. THis PR adds helper util for it.

* Jira link, if available
https://phildotus.atlassian.net/browse/HCPDEV-222

## Type of change

[ ] Bug Fix
[x] New Fearure

## Changes

* Added `GetPhilRxColorLogoURL` to get the color PhilRx logo

## Impact

* Any infrastructure related impact
* Any security related impact
