### PR TITLE
Rename AutoComm voice mail API to voice call

### DIFF
--- a/pkg/awscomm/README.md
+++ b/pkg/awscomm/README.md
@@ -77,18 +77,18 @@ pdfBytes, _ := os.ReadFile("document.pdf")
 response, err := client.SendFaxByContentBytes(ctx, "+1234567890", "https://callback.example.com", pdfBytes, nil)
 ```
 
-### Send Voice Mail
+### Send Voice Call
 
 ```go
-request := &awscomm.VoiceMailRequest{
+request := &awscomm.VoiceCallRequest{
     CallbackURL: "https://callback.example.com",
-    Payload: awscomm.VoiceMailPayload{
+    Payload: awscomm.VoiceCallPayload{
         ToPhoneNumber: "+1234567890",
         Message:       "This is a voice message",
     },
 }
 
-response, err := client.SendVoiceMail(ctx, request)
+response, err := client.SendVoiceCall(ctx, request)
 ```
 
 ## Query Parameters
@@ -154,8 +154,8 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
         // Handle email webhook
     case "fax":
         // Handle fax webhook
-    case "voice_mail":
-        // Handle voice mail webhook
+    case awscomm.COMM_TYPE_VOICE_CALL:
+        // Handle voice call webhook
     }
 
     w.WriteHeader(http.StatusOK)
@@ -169,7 +169,7 @@ type WebhookPayload struct {
     Payload      interface{}
     Metadata     interface{}
     Type         string // "internal" or "external"
-    CommType     string // "sms", "email", "fax", "voice_mail"
+    CommType     string // "sms", "email", "fax", "voice_mail" for voice calls
     Status       string // "QUEUED", "SENT", "FAILED"
     FailedReason string // Error message if status is FAILED
 }

--- a/pkg/awscomm/README.md
+++ b/pkg/awscomm/README.md
@@ -77,6 +77,20 @@ pdfBytes, _ := os.ReadFile("document.pdf")
 response, err := client.SendFaxByContentBytes(ctx, "+1234567890", "https://callback.example.com", pdfBytes, nil)
 ```
 
+### Send Voice Mail
+
+```go
+request := &awscomm.VoiceMailRequest{
+    CallbackURL: "https://callback.example.com",
+    Payload: awscomm.VoiceMailPayload{
+        ToPhoneNumber: "+1234567890",
+        Message:       "This is a voice message",
+    },
+}
+
+response, err := client.SendVoiceMail(ctx, request)
+```
+
 ### Send Voice Call
 
 ```go
@@ -154,8 +168,8 @@ func webhookHandler(w http.ResponseWriter, r *http.Request) {
         // Handle email webhook
     case "fax":
         // Handle fax webhook
-    case awscomm.COMM_TYPE_VOICE_CALL:
-        // Handle voice call webhook
+    case "voice_mail":
+        // Handle voice mail webhook
     }
 
     w.WriteHeader(http.StatusOK)
@@ -169,7 +183,7 @@ type WebhookPayload struct {
     Payload      interface{}
     Metadata     interface{}
     Type         string // "internal" or "external"
-    CommType     string // "sms", "email", "fax", "voice_mail" for voice calls
+    CommType     string // "sms", "email", "fax", "voice_mail"
     Status       string // "QUEUED", "SENT", "FAILED"
     FailedReason string // Error message if status is FAILED
 }

--- a/pkg/awscomm/client.go
+++ b/pkg/awscomm/client.go
@@ -80,7 +80,7 @@ func (c *Client) SendSMS(ctx context.Context, request *SMSRequest) (*Response, e
 	return c.sendRequest(ctx, url, request)
 }
 
-func (c *Client) SendVoiceMail(ctx context.Context, request *VoiceMailRequest) (*Response, error) {
+func (c *Client) SendVoiceCall(ctx context.Context, request *VoiceCallRequest) (*Response, error) {
 	if request.Payload.ToPhoneNumber == "" {
 		return nil, NewError("to_phone_number is required")
 	}
@@ -269,8 +269,8 @@ func (c *Client) sendRequest(ctx context.Context, url string, payload interface{
 		response, err = network.HTTPRequest[*SMSRequest, Response](
 			ctx, http.MethodPost, url, req, headers, 30,
 		)
-	case *VoiceMailRequest:
-		response, err = network.HTTPRequest[*VoiceMailRequest, Response](
+	case *VoiceCallRequest:
+		response, err = network.HTTPRequest[*VoiceCallRequest, Response](
 			ctx, http.MethodPost, url, req, headers, 30,
 		)
 	case *EmailRequest:

--- a/pkg/awscomm/client.go
+++ b/pkg/awscomm/client.go
@@ -80,6 +80,22 @@ func (c *Client) SendSMS(ctx context.Context, request *SMSRequest) (*Response, e
 	return c.sendRequest(ctx, url, request)
 }
 
+func (c *Client) SendVoiceMail(ctx context.Context, request *VoiceMailRequest) (*Response, error) {
+	if request.Payload.ToPhoneNumber == "" {
+		return nil, NewError("to_phone_number is required")
+	}
+
+	if request.Payload.Message == "" && request.Payload.TwiML == "" {
+		return nil, NewError("message or twiml is required")
+	}
+
+	url, err := c.buildURL("/send/voice_mail")
+	if err != nil {
+		return nil, err
+	}
+	return c.sendRequest(ctx, url, request)
+}
+
 func (c *Client) SendVoiceCall(ctx context.Context, request *VoiceCallRequest) (*Response, error) {
 	if request.Payload.ToPhoneNumber == "" {
 		return nil, NewError("to_phone_number is required")
@@ -267,6 +283,10 @@ func (c *Client) sendRequest(ctx context.Context, url string, payload interface{
 	switch req := payload.(type) {
 	case *SMSRequest:
 		response, err = network.HTTPRequest[*SMSRequest, Response](
+			ctx, http.MethodPost, url, req, headers, 30,
+		)
+	case *VoiceMailRequest:
+		response, err = network.HTTPRequest[*VoiceMailRequest, Response](
 			ctx, http.MethodPost, url, req, headers, 30,
 		)
 	case *VoiceCallRequest:

--- a/pkg/awscomm/client_test.go
+++ b/pkg/awscomm/client_test.go
@@ -69,20 +69,20 @@ func TestSendSMS_ValidationErrors(t *testing.T) {
 	}
 }
 
-func TestSendVoiceMail_ValidationErrors(t *testing.T) {
+func TestSendVoiceCall_ValidationErrors(t *testing.T) {
 	client := NewClient(baseURL, serviceName, serviceApiKey)
 	ctx := context.Background()
 
 	tests := []struct {
 		name        string
-		request     *VoiceMailRequest
+		request     *VoiceCallRequest
 		expectError bool
 	}{
 		{
 			name: "missing phone number",
-			request: &VoiceMailRequest{
+			request: &VoiceCallRequest{
 				CallbackURL: "https://example.com/callback",
-				Payload: VoiceMailPayload{
+				Payload: VoiceCallPayload{
 					ToPhoneNumber: "",
 					Message:       "Test message",
 				},
@@ -91,9 +91,9 @@ func TestSendVoiceMail_ValidationErrors(t *testing.T) {
 		},
 		{
 			name: "missing message and twiml",
-			request: &VoiceMailRequest{
+			request: &VoiceCallRequest{
 				CallbackURL: "https://example.com/callback",
-				Payload: VoiceMailPayload{
+				Payload: VoiceCallPayload{
 					ToPhoneNumber: "+17609579111",
 					Message:       "",
 				},
@@ -104,7 +104,7 @@ func TestSendVoiceMail_ValidationErrors(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, err := client.SendVoiceMail(ctx, tt.request)
+			_, err := client.SendVoiceCall(ctx, tt.request)
 			if tt.expectError {
 				assert.Error(t, err)
 			} else {
@@ -114,38 +114,38 @@ func TestSendVoiceMail_ValidationErrors(t *testing.T) {
 	}
 }
 
-func TestSendVoiceMail_AllowsTwiMLPayload(t *testing.T) {
-	var captured VoiceMailRequest
+func TestSendVoiceCall_AllowsTwiMLPayload(t *testing.T) {
+	var captured VoiceCallRequest
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/send/voice_mail", r.URL.Path)
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
 
 		w.Header().Set("Content-Type", "application/json")
-		_, err := w.Write([]byte(`{"status":"QUEUED","comm_request_id":"voice-mail-test","type":"voice_mail"}`))
+		_, err := w.Write([]byte(`{"status":"QUEUED","comm_request_id":"voice-call-test","type":"voice_mail"}`))
 		require.NoError(t, err)
 	}))
 	defer server.Close()
 
 	client := NewClient(server.URL, serviceName, serviceApiKey)
-	resp, err := client.SendVoiceMail(context.Background(), &VoiceMailRequest{
+	resp, err := client.SendVoiceCall(context.Background(), &VoiceCallRequest{
 		CallbackURL: "https://example.com/callback",
-		Payload: VoiceMailPayload{
+		Payload: VoiceCallPayload{
 			ToPhoneNumber: "+17609579111",
 			TwiML:         `<?xml version="1.0" encoding="UTF-8"?><Response><Say>Hello</Say></Response>`,
 		},
 	})
 
 	require.NoError(t, err)
-	assert.Equal(t, "voice-mail-test", resp.CommRequestID)
+	assert.Equal(t, "voice-call-test", resp.CommRequestID)
 	assert.Equal(t, "+17609579111", captured.Payload.ToPhoneNumber)
 	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?><Response><Say>Hello</Say></Response>`, captured.Payload.TwiML)
 	assert.Empty(t, captured.Payload.Message)
 }
 
-func TestVoiceMailRequest_MarshalsTwiMLPayload(t *testing.T) {
-	req := VoiceMailRequest{
+func TestVoiceCallRequest_MarshalsTwiMLPayload(t *testing.T) {
+	req := VoiceCallRequest{
 		CallbackURL: "https://example.com/callback",
-		Payload: VoiceMailPayload{
+		Payload: VoiceCallPayload{
 			ToPhoneNumber: "+18024712700",
 			TwiML:         `<?xml version="1.0" encoding="UTF-8"?><Response><Say>Hello</Say></Response>`,
 		},

--- a/pkg/awscomm/client_test.go
+++ b/pkg/awscomm/client_test.go
@@ -69,6 +69,103 @@ func TestSendSMS_ValidationErrors(t *testing.T) {
 	}
 }
 
+func TestSendVoiceMail_ValidationErrors(t *testing.T) {
+	client := NewClient(baseURL, serviceName, serviceApiKey)
+	ctx := context.Background()
+
+	tests := []struct {
+		name        string
+		request     *VoiceMailRequest
+		expectError bool
+	}{
+		{
+			name: "missing phone number",
+			request: &VoiceMailRequest{
+				CallbackURL: "https://example.com/callback",
+				Payload: VoiceMailPayload{
+					ToPhoneNumber: "",
+					Message:       "Test message",
+				},
+			},
+			expectError: true,
+		},
+		{
+			name: "missing message and twiml",
+			request: &VoiceMailRequest{
+				CallbackURL: "https://example.com/callback",
+				Payload: VoiceMailPayload{
+					ToPhoneNumber: "+17609579111",
+					Message:       "",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := client.SendVoiceMail(ctx, tt.request)
+			if tt.expectError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestSendVoiceMail_AllowsTwiMLPayload(t *testing.T) {
+	var captured VoiceMailRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/send/voice_mail", r.URL.Path)
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&captured))
+
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(`{"status":"QUEUED","comm_request_id":"voice-mail-test","type":"voice_mail"}`))
+		require.NoError(t, err)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, serviceName, serviceApiKey)
+	resp, err := client.SendVoiceMail(context.Background(), &VoiceMailRequest{
+		CallbackURL: "https://example.com/callback",
+		Payload: VoiceMailPayload{
+			ToPhoneNumber: "+17609579111",
+			TwiML:         `<?xml version="1.0" encoding="UTF-8"?><Response><Say>Hello</Say></Response>`,
+		},
+	})
+
+	require.NoError(t, err)
+	assert.Equal(t, "voice-mail-test", resp.CommRequestID)
+	assert.Equal(t, "+17609579111", captured.Payload.ToPhoneNumber)
+	assert.Equal(t, `<?xml version="1.0" encoding="UTF-8"?><Response><Say>Hello</Say></Response>`, captured.Payload.TwiML)
+	assert.Empty(t, captured.Payload.Message)
+}
+
+func TestVoiceMailRequest_MarshalsTwiMLPayload(t *testing.T) {
+	req := VoiceMailRequest{
+		CallbackURL: "https://example.com/callback",
+		Payload: VoiceMailPayload{
+			ToPhoneNumber: "+18024712700",
+			TwiML:         `<?xml version="1.0" encoding="UTF-8"?><Response><Say>Hello</Say></Response>`,
+		},
+		Metadata: map[string]any{
+			"order_number": "1234-1234-1234",
+		},
+	}
+
+	raw, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var payload map[string]any
+	require.NoError(t, json.Unmarshal(raw, &payload))
+
+	voicePayload := payload["payload"].(map[string]any)
+	assert.Equal(t, "+18024712700", voicePayload["to_phone_number"])
+	assert.Equal(t, req.Payload.TwiML, voicePayload["twiml"])
+	assert.NotContains(t, voicePayload, "message")
+}
+
 func TestSendVoiceCall_ValidationErrors(t *testing.T) {
 	client := NewClient(baseURL, serviceName, serviceApiKey)
 	ctx := context.Background()

--- a/pkg/awscomm/constants.go
+++ b/pkg/awscomm/constants.go
@@ -20,7 +20,7 @@ const (
 const (
 	COMM_TYPE_SMS        = "sms"
 	COMM_TYPE_EMAIL      = "email"
-	COMM_TYPE_VOICE_MAIL = "voice_mail"
+	COMM_TYPE_VOICE_CALL = "voice_mail" // TODO: update the step function later
 	COMM_TYPE_FAX        = "fax"
 )
 

--- a/pkg/awscomm/constants.go
+++ b/pkg/awscomm/constants.go
@@ -20,7 +20,8 @@ const (
 const (
 	COMM_TYPE_SMS        = "sms"
 	COMM_TYPE_EMAIL      = "email"
-	COMM_TYPE_VOICE_CALL = "voice_mail" // TODO: update the step function later
+	COMM_TYPE_VOICE_MAIL = "voice_mail"
+	COMM_TYPE_VOICE_CALL = COMM_TYPE_VOICE_MAIL
 	COMM_TYPE_FAX        = "fax"
 )
 

--- a/pkg/awscomm/models.go
+++ b/pkg/awscomm/models.go
@@ -13,6 +13,19 @@ type SMSPayload struct {
 	FromType      string `json:"from_type"`
 }
 
+type VoiceMailRequest struct {
+	CallbackURL            string           `json:"callback_url"`
+	Payload                VoiceMailPayload `json:"payload"`
+	SkipDuplicateDetection bool             `json:"skip_duplicate_detection"`
+	Metadata               map[string]any   `json:"metadata"`
+}
+
+type VoiceMailPayload struct {
+	ToPhoneNumber string `json:"to_phone_number"`
+	Message       string `json:"message,omitempty"`
+	TwiML         string `json:"twiml,omitempty"`
+}
+
 type VoiceCallRequest struct {
 	CallbackURL            string           `json:"callback_url"`
 	Payload                VoiceCallPayload `json:"payload"`
@@ -77,7 +90,7 @@ type FaxPayload struct {
 type Response struct {
 	Status        string `json:"status"`          // e.g., "QUEUED"
 	CommRequestID string `json:"comm_request_id"` // UUID
-	Type          string `json:"type"`            // e.g., "sms", "email", "fax", "voice_mail" for voice calls
+	Type          string `json:"type"`            // e.g., "sms", "email", "fax", "voice_mail"
 }
 
 // All error responses (400, 401, 404, 500) use the "message" field

--- a/pkg/awscomm/models.go
+++ b/pkg/awscomm/models.go
@@ -13,14 +13,14 @@ type SMSPayload struct {
 	FromType      string `json:"from_type"`
 }
 
-type VoiceMailRequest struct {
+type VoiceCallRequest struct {
 	CallbackURL            string           `json:"callback_url"`
-	Payload                VoiceMailPayload `json:"payload"`
+	Payload                VoiceCallPayload `json:"payload"`
 	SkipDuplicateDetection bool             `json:"skip_duplicate_detection"`
 	Metadata               map[string]any   `json:"metadata"`
 }
 
-type VoiceMailPayload struct {
+type VoiceCallPayload struct {
 	ToPhoneNumber string `json:"to_phone_number"`
 	Message       string `json:"message,omitempty"`
 	TwiML         string `json:"twiml,omitempty"`
@@ -77,7 +77,7 @@ type FaxPayload struct {
 type Response struct {
 	Status        string `json:"status"`          // e.g., "QUEUED"
 	CommRequestID string `json:"comm_request_id"` // UUID
-	Type          string `json:"type"`            // e.g., "sms", "email", "fax", "voice_mail"
+	Type          string `json:"type"`            // e.g., "sms", "email", "fax", "voice_mail" for voice calls
 }
 
 // All error responses (400, 401, 404, 500) use the "message" field

--- a/pkg/awscomm/webhook.go
+++ b/pkg/awscomm/webhook.go
@@ -11,7 +11,7 @@ type WebhookPayload struct {
 	Payload       map[string]any    `json:"payload"`
 	Metadata      map[string]string `json:"metadata"`
 	Type          string            `json:"type"`         // "internal" or "external"
-	CommType      string            `json:"commType"`     // e.g., "sms", "email", "fax", "voice_mail" for voice calls
+	CommType      string            `json:"commType"`     // e.g., "sms", "email", "fax", "voice_mail"
 	Status        string            `json:"status"`       // e.g., "QUEUED", "FAILED"
 	FailedReason  string            `json:"failedReason"` // Error message if failed
 	CommRequestId string            `json:"commRequestId"`

--- a/pkg/awscomm/webhook.go
+++ b/pkg/awscomm/webhook.go
@@ -11,7 +11,7 @@ type WebhookPayload struct {
 	Payload       map[string]any    `json:"payload"`
 	Metadata      map[string]string `json:"metadata"`
 	Type          string            `json:"type"`         // "internal" or "external"
-	CommType      string            `json:"commType"`     // e.g., "sms", "email", "fax", "voice_mail"
+	CommType      string            `json:"commType"`     // e.g., "sms", "email", "fax", "voice_mail" for voice calls
 	Status        string            `json:"status"`       // e.g., "QUEUED", "FAILED"
 	FailedReason  string            `json:"failedReason"` // Error message if failed
 	CommRequestId string            `json:"commRequestId"`


### PR DESCRIPTION

## Description of the change

> Rename the TwiML-based AutoComm voice send client from voice mail to voice call terminology so it matches the Twilio behavior. Keep the existing /send/voice_mail endpoint and voice_mail comm type as the external AutoComm wire contract for now.

* Jira [link](https://phildotus.atlassian.net/browse/PEXP-1506)

## Type of change
- [x] Refactor

### Testing

<img width="1370" height="2044" alt="image" src="https://github.com/user-attachments/assets/258df04c-6dcc-4643-9250-97ac9a94c19c" />
